### PR TITLE
feat(packages): implement full packages management

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import {LayoutComponent} from "./component/layout/layout.component";
 import {authGuard} from "./guards/auth.guard";
 import {guestGuard} from "./guards/guest.guard";
 import {PayoutsComponent} from "./component/payouts/payouts.component";
+import {PackagesComponent} from "./component/packages/packages.component";
 
 export const routes: Routes = [
   {
@@ -14,8 +15,9 @@ export const routes: Routes = [
       {
         path: 'affiliate', children: [
           {path: 'payouts', component: PayoutsComponent}
-        ]
-      }
+        ],
+      },
+      {path: 'packages', component: PackagesComponent}
     ]
   },
 

--- a/src/app/component/header/header.component.html
+++ b/src/app/component/header/header.component.html
@@ -10,7 +10,7 @@
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav me-auto">
         <li class="nav-item">
-          <a class="nav-link active" href="#">Dashboard</a>
+          <a class="nav-link" href="#">Dashboard</a>
         </li>
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button"
@@ -22,6 +22,10 @@
                    [routerLink]="['/affiliate','payouts']">Payouts</a>
             </li>
           </ul>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="#" (click)="$event.preventDefault();"
+             [routerLink]="['packages']">Packages</a>
         </li>
       </ul>
 

--- a/src/app/component/packages/packagemodal/packagemodal.component.html
+++ b/src/app/component/packages/packagemodal/packagemodal.component.html
@@ -1,0 +1,125 @@
+<div class="modal-backdrop fade show" *ngIf="show"></div>
+
+<div class="modal fade show d-block" tabindex="-1" *ngIf="show">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <form [formGroup]="form" (ngSubmit)="onSubmit()" novalidate>
+        <div class="modal-header">
+          <h5 class="modal-title">Create Package</h5>
+          <button type="button" class="btn-close" (click)="onCancel()" aria-label="Close"></button>
+        </div>
+
+        <div class="modal-body">
+          <!-- Name -->
+          <div class="mb-3">
+            <label class="form-label">Name</label>
+            <input class="form-control"
+                   formControlName="name"
+                   placeholder="e.g., Bronze Package"
+                   [ngClass]="{'is-invalid': form.get('name')?.touched && form.get('name')?.invalid}">
+            <div class="invalid-feedback">
+              Name is required (max 128 chars).
+            </div>
+          </div>
+
+          <!-- Description -->
+          <div class="mb-3">
+            <label class="form-label">Description</label>
+            <textarea class="form-control"
+                      rows="3"
+                      formControlName="description"
+                      placeholder="Short description..."></textarea>
+          </div>
+
+          <!-- Price -->
+          <div class="mb-3">
+            <label class="form-label">Price</label>
+            <div class="input-group">
+              <span class="input-group-text">€</span>
+              <input type="number"
+                     class="form-control"
+                     formControlName="price"
+                     inputmode="decimal"
+                     min="0" step="0.01"
+                     placeholder="0.00"
+                     (input)="onPriceInput($event)"
+                     (keydown)="allowOnlyNumbers($event)"
+                     [ngClass]="{'is-invalid': form.get('price')?.touched && form.get('price')?.invalid}">
+              <div class="invalid-feedback">
+                Price must be a non-negative number.
+              </div>
+            </div>
+          </div>
+
+
+          <hr>
+
+          <!-- Add Privilege -->
+          <div class="dropdown mb-3">
+            <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown">
+              + Add Privilege
+            </button>
+            <ul class="dropdown-menu">
+              <li *ngFor="let t of privilegeTypes">
+                <button class="dropdown-item" type="button" (click)="addPrivilege(t)">
+                  {{ PrivilegeTypeLabels[t] }}
+                </button>
+              </li>
+            </ul>
+          </div>
+
+          <!-- Privileges -->
+          <div *ngIf="privileges.controls.length === 0" class="text-muted">
+            No privileges added yet.
+          </div>
+
+          <div class="privileges-scroll mt-2" *ngIf="privileges.controls.length > 0">
+            <div class="row row-cols-1 row-cols-md-2 g-3 mx-0">
+              <div class="col" *ngFor="let grp of privileges.controls; let i = index" [formGroup]="$any(grp)">
+                <div class="card h-100 shadow-sm">
+                  <div class="card-header d-flex justify-content-between align-items-center">
+                    <strong>Privilege #{{ i + 1 }}</strong>
+                    <button type="button" class="btn btn-sm btn-outline-danger" (click)="removePrivilege(i)">
+                      Remove
+                    </button>
+                  </div>
+
+                  <div class="card-body">
+                    <span class="badge bg-secondary mb-3 text-break">{{ grp.get('type')?.value }}</span>
+
+                    <!-- Role -->
+                    <div *ngIf="grp.get('type')?.value === PrivilegeType.ROLE">
+                      <label class="form-label">Role</label>
+                      <select class="form-select" formControlName="role">
+                        <option *ngFor="let r of roles" [ngValue]="r">{{ RoleLabels[r] }}</option>
+                      </select>
+                    </div>
+
+                    <!-- Allowlist -->
+                    <div *ngIf="grp.get('type')?.value === PrivilegeType.ALLOWLIST">
+                      <label class="form-label">Whitelist slots</label>
+                      <input type="number"
+                             class="form-control"
+                             formControlName="whitelistSlots"
+                             min="1" step="1"
+                             placeholder="e.g., 5"
+                             [ngClass]="{'is-invalid': grp.get('whitelistSlots')?.touched && grp.get('whitelistSlots')?.invalid}">
+                      <div class="invalid-feedback">Must be at least 1.</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <!-- Footer -->
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" (click)="onCancel()">Cancel</button>
+          <button type="submit" class="btn btn-primary" [disabled]="form.invalid">Create</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/src/app/component/packages/packagemodal/packagemodal.component.scss
+++ b/src/app/component/packages/packagemodal/packagemodal.component.scss
@@ -1,0 +1,7 @@
+.privileges-scroll {
+  max-height: 30vh;
+  overflow-y: auto;
+}
+
+.privileges-scroll .col { min-width: 0; }
+

--- a/src/app/component/packages/packagemodal/packagemodal.component.spec.ts
+++ b/src/app/component/packages/packagemodal/packagemodal.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PackageModalComponent } from './packagemodal.component';
+
+describe('PackagemodalComponent', () => {
+  let component: PackageModalComponent;
+  let fixture: ComponentFixture<PackageModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PackageModalComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PackageModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/component/packages/packagemodal/packagemodal.component.ts
+++ b/src/app/component/packages/packagemodal/packagemodal.component.ts
@@ -1,0 +1,181 @@
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {PackageCreateDto} from "../../../dto/PackageDtos";
+import {FormArray, FormBuilder, FormGroup, ReactiveFormsModule, Validators} from "@angular/forms";
+import {
+  AffiliatePrivilegeDto,
+  AllowListPrivilegeDto,
+  PrivilegeType,
+  PrivilegeTypeLabels,
+  Role,
+  RoleLabels,
+  RolePrivilegeDto
+} from "../../../dto/PrivilegeDtos";
+import {CommonModule, NgForOf, NgIf} from "@angular/common";
+
+type FormPrivilege =
+  | { type: PrivilegeType.AFFILIATE }
+  | { type: PrivilegeType.ROLE; role: Role }
+  | { type: PrivilegeType.ALLOWLIST; whitelistSlots: number };
+
+
+@Component({
+  selector: 'app-packagemodal',
+  standalone: true,
+  imports: [CommonModule,
+    ReactiveFormsModule,
+    NgIf,
+    NgForOf
+  ],
+  templateUrl: './packagemodal.component.html',
+  styleUrl: './packagemodal.component.scss'
+})
+export class PackageModalComponent implements OnInit {
+  @Input() open: boolean = false;
+  @Input() show: boolean = false;
+  @Output() cancel = new EventEmitter<void>();
+  @Output() confirm = new EventEmitter<PackageCreateDto>();
+
+  form: FormGroup;
+
+  roles = Object.values(Role);
+  privilegeTypes = Object.values(PrivilegeType);
+
+
+  constructor(private fb: FormBuilder) {
+  }
+
+
+  ngOnInit(): void {
+    this.initForm();
+  }
+
+
+  initForm() {
+    this.form = this.fb.group({
+      name: ['', Validators.required],
+      description: [''],
+      price: [0, [Validators.required, Validators.min(0), Validators.pattern("^\d+([.]\d{0,2})?$")]],
+      privileges: this.fb.array([])
+    });
+  }
+
+
+  get privileges(): FormArray {
+    return this.form.get('privileges') as FormArray;
+  }
+
+  addPrivilege(type: PrivilegeType) {
+    switch (type) {
+      case PrivilegeType.AFFILIATE:
+        this.privileges.push(this.fb.group({
+          type: [PrivilegeType.AFFILIATE, Validators.required],
+        }));
+        break;
+
+      case PrivilegeType.ROLE:
+        this.privileges.push(this.fb.group({
+          type: [PrivilegeType.ROLE, Validators.required],
+          role: [this.roles[0], Validators.required],
+        }));
+        break;
+
+      case PrivilegeType.ALLOWLIST:
+        this.privileges.push(this.fb.group({
+          type: [PrivilegeType.ALLOWLIST, Validators.required],
+          whitelistSlots: [1, [Validators.required, Validators.min(1)]],
+        }));
+        break;
+    }
+  }
+
+  removePrivilege(index: number) {
+    this.privileges.removeAt(index);
+  }
+
+  onCancel(): void {
+    this.cancel.emit();
+    this.show = false;
+  }
+
+  onPriceInput(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const inputVal = input.value;
+    if (!inputVal) return;
+    if (inputVal === '.') input.value = String(0.0)
+    if (inputVal.length > 15) input.value = inputVal.slice(0, 15);
+
+    const floatVal = parseFloat(input.value);
+    const [, decPart = ''] = input.value.split('.');
+    if (decPart && decPart.length > 2) {
+      const newval = Math.round((floatVal + Number.EPSILON) * 100) / 100;
+      input.value = newval.toString();
+      this.form.get('price')?.setValue(newval, {emitEvent: false});
+    }
+  }
+
+  allowOnlyNumbers(event: KeyboardEvent) {
+    const allowedChars = /[0-9.,]/;
+    const controlKeys = [
+      'Backspace',
+      'Delete',
+      'ArrowLeft',
+      'ArrowRight',
+      'Tab',
+      'Home',
+      'End'
+    ];
+
+    if (controlKeys.includes(event.key)) {
+      return;
+    }
+
+    if ((event.ctrlKey || event.metaKey) && ['a', 'c', 'v', 'x'].includes(event.key.toLowerCase())) {
+      return;
+    }
+
+
+    if (!allowedChars.test(event.key)) {
+      event.preventDefault();
+    }
+  }
+
+
+  onSubmit() {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const raw = this.form.getRawValue();
+    const dto: PackageCreateDto = {
+      name: raw.name,
+      description: raw.description,
+      price: raw.price,
+      privileges: (raw.privileges as FormPrivilege[]).map((p) => {
+        switch (p.type) {
+          case PrivilegeType.AFFILIATE:
+            return new AffiliatePrivilegeDto();
+
+          case PrivilegeType.ROLE: {
+            const roleDto = new RolePrivilegeDto();
+            roleDto.role = p.role;
+            return roleDto;
+          }
+
+          case PrivilegeType.ALLOWLIST: {
+            const listDto = new AllowListPrivilegeDto();
+            listDto.whitelistSlots = p.whitelistSlots; // ✅ camelCase
+            return listDto;
+          }
+        }
+      })
+
+    }
+    this.confirm.emit(dto);
+    this.show = false;
+  }
+
+  protected readonly PrivilegeType = PrivilegeType;
+  protected readonly RoleLabels = RoleLabels;
+  protected readonly PrivilegeTypeLabels = PrivilegeTypeLabels;
+}

--- a/src/app/component/packages/packages.component.html
+++ b/src/app/component/packages/packages.component.html
@@ -1,0 +1,1 @@
+<p>packages works!</p>

--- a/src/app/component/packages/packages.component.html
+++ b/src/app/component/packages/packages.component.html
@@ -1,1 +1,20 @@
-<p>packages works!</p>
+<div class="container mt-4">
+  <h2>Packages</h2>
+  <div class="d-flex justify-content-between align-items-end">
+    <button class="btn btn-primary" (click)="openCreateModal()">Create Package</button>
+  </div>
+
+  <div class="row g-3 mt-3">
+    <div class="col-sm-6 col-md-4 col-lg-3" *ngFor="let p of packages">
+      <div class="card h-100 shadow-sm">
+        <div class="card-body d-flex flex-column">
+          <h5 class="card-title">{{ p.name }}</h5>
+          <p class="card-text text-muted flex-grow-1">{{ p.description }}</p>
+          <div class="mt-auto fw-bold">
+            {{ Formatter.formatMoney(p.price) }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/component/packages/packages.component.html
+++ b/src/app/component/packages/packages.component.html
@@ -18,3 +18,9 @@
     </div>
   </div>
 </div>
+
+<app-packagemodal
+  [show]="showCreateModal"
+  (confirm)="createPackage($event)"
+  (cancel)="closeCreateModal()">
+</app-packagemodal>

--- a/src/app/component/packages/packages.component.html
+++ b/src/app/component/packages/packages.component.html
@@ -5,11 +5,34 @@
   </div>
 
   <div class="row g-3 mt-3">
-    <div class="col-sm-6 col-md-4 col-lg-3" *ngFor="let p of packages">
+    <div class="col-sm-6 col-md-4 col-lg-3" *ngFor="let p of packages; let i = index">
       <div class="card h-100 shadow-sm">
-        <div class="card-body d-flex flex-column">
-          <h5 class="card-title">{{ p.name }}</h5>
-          <p class="card-text text-muted flex-grow-1">{{ p.description }}</p>
+        <div class="card-header" (click)="$event.stopPropagation()">
+          <div class="form-check form-switch d-flex align-items-center m-0">
+            <input
+              class="form-check-input"
+              type="checkbox"
+              role="switch"
+              [id]="'pkg-active-switch-' + i"
+              [checked]="p.active"
+              (click)="$event.preventDefault(); openConfirmModal(p)"
+              [ngClass]="p.active ? 'bg-success border-success' : 'bg-secondary border-secondary'"
+            />
+            <label
+              class="form-check-label ms-2 small"
+              [for]="'pkg-active-switch-' + i"
+              [ngClass]="p.active ? 'text-success' : 'text-muted'"
+            >
+              {{ p.active ? 'Active' : 'Inactive' }}
+            </label>
+          </div>
+        </div>
+
+        <div class="card-body d-flex flex-column cursor-pointer" (click)="openDetailsModal(p)" tabindex="0">
+          <h5 class="card-title mb-2">{{ p.name }}</h5>
+          <p class="card-text text-muted flex-grow-1 line-clamp-2" [title]="p.description">
+            {{ p.description }}
+          </p>
           <div class="mt-auto fw-bold">
             {{ Formatter.formatMoney(p.price) }}
           </div>
@@ -17,10 +40,49 @@
       </div>
     </div>
   </div>
+  <ng-container *ngIf="showDetails" [ngTemplateOutlet]="detailsModal"></ng-container>
 </div>
+
+<app-confirm-dialog
+  [show]="showConfirmModal"
+  message="Are you sure you want to {{selected?.active?'de':''}}activate this package?"
+  (confirmed)="confirmPackageChange()"
+  (cancelled)="closeConfirmModal()"
+>
+</app-confirm-dialog>
 
 <app-packagemodal
   [show]="showCreateModal"
   (confirm)="createPackage($event)"
   (cancel)="closeCreateModal()">
 </app-packagemodal>
+
+<ng-template #detailsModal>
+  <div class="modal fade show d-block" tabindex="-1">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+      <div class="modal-content" (click)="$event.stopPropagation()">
+        <div class="modal-header">
+          <h5 class="modal-title">{{ selected?.name }}</h5>
+          <button type="button" class="btn-close" (click)="closeDetailsModal()" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="d-flex align-items-center gap-2 mb-2">
+          <span class="badge" [ngClass]="selected?.active ? 'bg-success' : 'bg-secondary'">
+            {{ selected?.active ? 'Active' : 'Inactive' }}
+          </span>
+            <span class="fw-semibold">{{ Formatter.formatMoney(selected?.price) }}</span>
+            <span class="text-muted" *ngIf="selected?.currency">• {{ selected?.currency }}</span>
+          </div>
+          <p class="mb-0" style="white-space: pre-wrap">{{ selected?.description }}</p>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline-secondary" (click)="closeDetailsModal()">Close</button>
+          <button class="btn btn-primary" (click)="openConfirmModal(selected!)">
+            {{ selected?.active ? 'Deactivate' : 'Activate' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="modal-backdrop fade show" (click)="closeDetailsModal()"></div>
+</ng-template>

--- a/src/app/component/packages/packages.component.scss
+++ b/src/app/component/packages/packages.component.scss
@@ -1,0 +1,8 @@
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.cursor-pointer { cursor: pointer; }

--- a/src/app/component/packages/packages.component.spec.ts
+++ b/src/app/component/packages/packages.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PackagesComponent } from './packages.component';
+
+describe('PackagesComponent', () => {
+  let component: PackagesComponent;
+  let fixture: ComponentFixture<PackagesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PackagesComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(PackagesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/component/packages/packages.component.ts
+++ b/src/app/component/packages/packages.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-packages',
+  standalone: true,
+  imports: [],
+  templateUrl: './packages.component.html',
+  styleUrl: './packages.component.scss'
+})
+export class PackagesComponent {
+
+}

--- a/src/app/component/packages/packages.component.ts
+++ b/src/app/component/packages/packages.component.ts
@@ -1,12 +1,41 @@
-import { Component } from '@angular/core';
+import {Component, OnInit} from '@angular/core';
+import {PackageDto} from "../../dto/PackageDtos";
+import {PackageService} from "../../services/packages.service";
+import {ToastrService} from "ngx-toastr";
+import {NgForOf} from "@angular/common";
+import {Formatter} from "../../utils/Formatter";
 
 @Component({
   selector: 'app-packages',
   standalone: true,
-  imports: [],
+  imports: [
+    NgForOf
+  ],
   templateUrl: './packages.component.html',
   styleUrl: './packages.component.scss'
 })
-export class PackagesComponent {
+export class PackagesComponent implements OnInit {
 
+  packages: PackageDto[] = [];
+
+  ngOnInit(): void {
+    this.loadPackages();
+  }
+
+  constructor(private service: PackageService, private toastr: ToastrService) {
+  }
+
+  loadPackages() {
+    this.service.getPackages().subscribe({
+      next: (data) => {
+        this.packages = data.packages;
+      },
+      error: (err) => {
+        this.toastr.error(err.error.error);
+      }
+    })
+  }
+
+
+  protected readonly Formatter = Formatter;
 }

--- a/src/app/component/packages/packages.component.ts
+++ b/src/app/component/packages/packages.component.ts
@@ -1,15 +1,19 @@
 import {Component, OnInit} from '@angular/core';
-import {PackageDto} from "../../dto/PackageDtos";
+import {PackageCreateDto, PackageDto} from "../../dto/PackageDtos";
 import {PackageService} from "../../services/packages.service";
 import {ToastrService} from "ngx-toastr";
 import {NgForOf} from "@angular/common";
 import {Formatter} from "../../utils/Formatter";
+import {PackageModalComponent} from "./packagemodal/packagemodal.component";
+import {ConfirmDialogComponent} from "../shared/confirm-dialog/confirm-dialog.component";
 
 @Component({
   selector: 'app-packages',
   standalone: true,
   imports: [
     NgForOf
+    NgForOf,
+    PackageModalComponent,
   ],
   templateUrl: './packages.component.html',
   styleUrl: './packages.component.scss'
@@ -17,6 +21,7 @@ import {Formatter} from "../../utils/Formatter";
 export class PackagesComponent implements OnInit {
 
   packages: PackageDto[] = [];
+  showCreateModal: boolean = false;
 
   ngOnInit(): void {
     this.loadPackages();
@@ -34,6 +39,28 @@ export class PackagesComponent implements OnInit {
         this.toastr.error(err.error.error);
       }
     })
+  }
+
+  createPackage(dto: PackageCreateDto) {
+    this.service.createPackage(dto).subscribe({
+      next: (data) => {
+        this.toastr.success("Package created");
+        this.packages.push(data);
+      },
+      error: (err) => {
+        this.toastr.error(err.error.error);
+      }
+    })
+    this.showCreateModal = false;
+  }
+
+  closeCreateModal() {
+    this.showCreateModal = false;
+  }
+
+  openCreateModal() {
+    this.showCreateModal = true;
+    console.log("open modal:", this.showCreateModal);
   }
 
 

--- a/src/app/component/packages/packages.component.ts
+++ b/src/app/component/packages/packages.component.ts
@@ -2,7 +2,7 @@ import {Component, OnInit} from '@angular/core';
 import {PackageCreateDto, PackageDto} from "../../dto/PackageDtos";
 import {PackageService} from "../../services/packages.service";
 import {ToastrService} from "ngx-toastr";
-import {NgForOf} from "@angular/common";
+import {NgClass, NgForOf, NgIf, NgTemplateOutlet} from "@angular/common";
 import {Formatter} from "../../utils/Formatter";
 import {PackageModalComponent} from "./packagemodal/packagemodal.component";
 import {ConfirmDialogComponent} from "../shared/confirm-dialog/confirm-dialog.component";
@@ -11,9 +11,12 @@ import {ConfirmDialogComponent} from "../shared/confirm-dialog/confirm-dialog.co
   selector: 'app-packages',
   standalone: true,
   imports: [
-    NgForOf
     NgForOf,
     PackageModalComponent,
+    ConfirmDialogComponent,
+    NgClass,
+    NgIf,
+    NgTemplateOutlet
   ],
   templateUrl: './packages.component.html',
   styleUrl: './packages.component.scss'
@@ -22,6 +25,9 @@ export class PackagesComponent implements OnInit {
 
   packages: PackageDto[] = [];
   showCreateModal: boolean = false;
+  showConfirmModal: boolean = false;
+  selected: PackageDto | null = null;
+  showDetails: boolean = false;
 
   ngOnInit(): void {
     this.loadPackages();
@@ -33,6 +39,7 @@ export class PackagesComponent implements OnInit {
   loadPackages() {
     this.service.getPackages().subscribe({
       next: (data) => {
+        console.log(data);
         this.packages = data.packages;
       },
       error: (err) => {
@@ -45,6 +52,7 @@ export class PackagesComponent implements OnInit {
     this.service.createPackage(dto).subscribe({
       next: (data) => {
         this.toastr.success("Package created");
+        data = {...data, active: true};
         this.packages.push(data);
       },
       error: (err) => {
@@ -61,6 +69,76 @@ export class PackagesComponent implements OnInit {
   openCreateModal() {
     this.showCreateModal = true;
     console.log("open modal:", this.showCreateModal);
+  }
+
+  openConfirmModal(packageDto: PackageDto) {
+    this.showDetails = false;
+    this.selected = packageDto;
+    this.showConfirmModal = true;
+  }
+
+  closeConfirmModal() {
+    this.showConfirmModal = false;
+    this.selected = null;
+  }
+
+  deletePackage() {
+    if (!this.selected) return;
+    if (!this.selected?.active) {
+      this.toastr.error("Cannot deactivate inactive package");
+      return;
+    }
+    const id = this.selected.id;
+    this.service.deletePackage(this.selected.id).subscribe({
+      next: () => {
+        this.toastr.success("Package deactivated");
+        this.setPackageActive(id, false);
+      },
+      error: (err) => {
+        this.toastr.error(err.error.error);
+      }
+    })
+    this.closeConfirmModal();
+  }
+
+  setPackageActive(id: number, active: boolean) {
+    console.log("Setting package active: ", id, " to: ", active, "")
+    this.packages = this.packages.map(p => p.id === id ? {...p, active: active} : p);
+    console.log(this.packages)
+  }
+
+  activatePackage() {
+    if (!this.selected) return;
+    if (this.selected?.active) {
+      this.toastr.error("Cannot activate active package");
+      return;
+    }
+    const id = this.selected.id;
+    this.service.activatePackage(this.selected.id).subscribe({
+      next: () => {
+        this.toastr.success("Package activated");
+        this.setPackageActive(id, true);
+      },
+      error: (err) => {
+        this.toastr.error(err.error.error);
+      }
+    })
+    this.closeConfirmModal();
+  }
+
+  confirmPackageChange() {
+    if (!this.selected) return;
+    this.selected.active ? this.deletePackage() : this.activatePackage();
+  }
+
+  openDetailsModal(packageDto: PackageDto) {
+    this.selected = packageDto;
+    this.showDetails = true;
+  }
+
+  closeDetailsModal() {
+    this.showDetails = false;
+    this.selected = null;
   }
 
 

--- a/src/app/dto/PackageDtos.ts
+++ b/src/app/dto/PackageDtos.ts
@@ -1,0 +1,22 @@
+import {PrivilegeDto} from "./PrivilegeDtos";
+
+export class PackageDto {
+
+  id: number;
+  name: string
+  price: number;
+  description: string;
+  currency: string;
+  active: boolean;
+}
+
+export class PackageFetchDto {
+  packages: PackageDto[];
+}
+
+export class PackageCreateDto {
+  name: string;
+  description: string;
+  price: number;
+  privileges: PrivilegeDto[];
+}

--- a/src/app/dto/PrivilegeDtos.ts
+++ b/src/app/dto/PrivilegeDtos.ts
@@ -1,21 +1,38 @@
 export class PrivilegeDto {
 }
 
+export enum PrivilegeType {
+  AFFILIATE = 'AFFILIATECODE', ROLE = 'ROLE', ALLOWLIST = 'WHITELISTSLOT'
+}
+
+export const PrivilegeTypeLabels: Record<PrivilegeType, String> = {
+  [PrivilegeType.AFFILIATE]: "Affiliate Code",
+  [PrivilegeType.ROLE]: "Role",
+  [PrivilegeType.ALLOWLIST]: "Allowlist Slot"
+}
+
 export class AffiliatePrivilegeDto extends PrivilegeDto {
-  type: 'AFFILIATECODE';
+  type: PrivilegeType = PrivilegeType.AFFILIATE
 }
 
 export class RolePrivilegeDto extends PrivilegeDto {
-  type: 'ROLE';
+  type: PrivilegeType = PrivilegeType.ROLE;
   role: Role;
 }
 
 export class AllowListPrivilegeDto extends PrivilegeDto {
-  type: 'WHITELISTSLOT';
+  type: PrivilegeType = PrivilegeType.ALLOWLIST;
   whitelistSlots: number;
 }
 
 
-enum Role {
-  ROLE_FAN, ROLE_INVESTOR, ROLE_VIP, ROLE_INFLUENCER
+export enum Role {
+  FAN = 'ROLE_FAN', INVESTOR = 'ROLE_INVESTOR', VIP = 'ROLE_VIP', INFLUENCER = 'ROLE_INFLUENCER'
+}
+
+export const RoleLabels: Record<Role, String> = {
+  [Role.FAN]: "Fan",
+  [Role.INVESTOR]: "Investor",
+  [Role.VIP]: "VIP",
+  [Role.INFLUENCER]: "Influencer"
 }

--- a/src/app/dto/PrivilegeDtos.ts
+++ b/src/app/dto/PrivilegeDtos.ts
@@ -1,0 +1,21 @@
+export class PrivilegeDto {
+}
+
+export class AffiliatePrivilegeDto extends PrivilegeDto {
+  type: 'AFFILIATECODE';
+}
+
+export class RolePrivilegeDto extends PrivilegeDto {
+  type: 'ROLE';
+  role: Role;
+}
+
+export class AllowListPrivilegeDto extends PrivilegeDto {
+  type: 'WHITELISTSLOT';
+  whitelistSlots: number;
+}
+
+
+enum Role {
+  ROLE_FAN, ROLE_INVESTOR, ROLE_VIP, ROLE_INFLUENCER
+}

--- a/src/app/globals/globals.ts
+++ b/src/app/globals/globals.ts
@@ -4,7 +4,7 @@ import {Injectable} from "@angular/core";
   providedIn: 'root'
 })
 export class Globals {
-  private static readonly backendUrl: string = 'http://194.182.175.77/api';
+  private static readonly backendUrl: string = 'https://dev.auraflow.at/api';
   static readonly defaultPageSize: number = 10;
 
   get backendUrl(): string {

--- a/src/app/services/packages.service.spec.ts
+++ b/src/app/services/packages.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PackagesService } from './packages.service';
+
+describe('PackagesService', () => {
+  let service: PackagesService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PackagesService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/packages.service.ts
+++ b/src/app/services/packages.service.ts
@@ -1,0 +1,32 @@
+import {Injectable} from '@angular/core';
+import {HttpClient} from "@angular/common/http";
+import {Globals} from "../globals/globals";
+import {Observable} from "rxjs";
+import {PackageCreateDto, PackageDto, PackageFetchDto} from "../dto/PackageDtos";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PackagesServic {
+  private baseUrl = this.globals.backendUrl + '/packages';
+
+  constructor(private http: HttpClient, private globals: Globals) {
+  }
+
+  getPackages(): Observable<PackageFetchDto> {
+    return this.http.get<PackageFetchDto>(this.baseUrl + '/all');
+  }
+
+  createPackage(dto: PackageCreateDto): Observable<PackageDto> {
+    return this.http.post<PackageDto>(this.baseUrl, dto);
+  }
+
+  deletePackage(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+
+  activatePackage(id: number): Observable<PackageDto> {
+    return this.http.put<PackageDto>(`${this.baseUrl}/${id}`, {});
+  }
+
+}

--- a/src/app/services/packages.service.ts
+++ b/src/app/services/packages.service.ts
@@ -7,7 +7,7 @@ import {PackageCreateDto, PackageDto, PackageFetchDto} from "../dto/PackageDtos"
 @Injectable({
   providedIn: 'root'
 })
-export class PackagesServic {
+export class PackageService {
   private baseUrl = this.globals.backendUrl + '/packages';
 
   constructor(private http: HttpClient, private globals: Globals) {


### PR DESCRIPTION
### Summary
Introduced a complete **Packages module** with UI, service integration, and modal-driven workflows for creation and activation/deactivation of packages.

### Changes
- **Services**
  - Added `PackagesService` with API methods for fetching, creating, deleting, and activating packages.
  - Introduced DTOs (`PackageDto`, `PackageFetchDto`, `PackageCreateDto`) and privilege-related DTOs.

- **Component**
  - Created standalone `PackagesComponent` with routing and navigation link.
  - Implemented dynamic package listing from the backend service.
  - Added toggle switch to activate/deactivate packages, backed by confirmation modal.
  - Added details modal to view package information.
  - Enhanced styling with line-clamp for descriptions and cursor-pointer interactions.

- **Modals**
  - **PackageModalComponent** for package creation:
    - Form validation and privilege management (Affiliate, Role, Allowlist).
    - Supports cancel/confirm events and responsive design.
  - Integrated `app-confirm-dialog` for activation/deactivation confirmation.

- **Fixes**
  - Corrected `PackagesService` class name.
  - Updated backend URL to secure dev environment.

### Motivation
This MR delivers the full packages management flow in the frontend:  
- Users can view packages, inspect details, create new ones, and activate/deactivate them safely via confirmation dialogs.  

### Closes
- #10 